### PR TITLE
Fixed name of app module (and link on metacpan)

### DIFF
--- a/lib/Calendar/Gregorian.pm
+++ b/lib/Calendar/Gregorian.pm
@@ -52,7 +52,7 @@ sub BUILD {
 =head1 DESCRIPTION
 
 Simple Gregorian Calendar interface and used by  another package L<App::calendr>.
-On installation of L<App::calendar> you get a handy command line tool B<calendr>.
+On installation of L<App::calendr> you get a handy command line tool B<calendr>.
 
 Look for more details in the pod for L<App::calendr>.
 


### PR DESCRIPTION
There was a typo in the name of the module, which also led to a broken link in metacpan.
